### PR TITLE
fix(generator): remove kernel_module_name due to API change

### DIFF
--- a/bitlocker.py
+++ b/bitlocker.py
@@ -204,7 +204,6 @@ class BitlockerFVEKScan(interfaces.plugins.PluginInterface):
         # Iterate pool headers that match our tags
         for constraint, pool in ps.PoolScanner.pool_scan(
             context=self.context,
-            kernel_module_name=self.config["kernel"],
             layer_name=kernel.layer_name,
             symbol_table=kernel.symbol_table_name,
             pool_constraints=constraints,


### PR DESCRIPTION
Due to an API change in volatility3 (version 2.8.0) `kernel_module_name` has been removed.